### PR TITLE
Fix release workflow — extract Python scripts, fix YAML syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,17 +32,17 @@ jobs:
             TAG="${BASE_TAG}.${COUNT}"
           done
 
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "year=$YEAR" >> $GITHUB_OUTPUT
-          echo "month=$MONTH" >> $GITHUB_OUTPUT
-          echo "day=$DAY" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "year=$YEAR" >> "$GITHUB_OUTPUT"
+          echo "month=$MONTH" >> "$GITHUB_OUTPUT"
+          echo "day=$DAY" >> "$GITHUB_OUTPUT"
           echo "Generated tag: $TAG"
 
       - name: Get commit hash
         id: commit
         run: |
           HASH=$(git rev-parse --short HEAD)
-          echo "hash=$HASH" >> $GITHUB_OUTPUT
+          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
 
       - name: Get commits since last tag
         id: commits
@@ -51,115 +51,39 @@ jobs:
           if [ -z "$LAST_TAG" ]; then
             COMMITS=$(git log --pretty=format:"- %s" HEAD)
           else
-            COMMITS=$(git log --pretty=format:"- %s" ${LAST_TAG}..HEAD)
+            COMMITS=$(git log --pretty=format:"- %s" "${LAST_TAG}..HEAD")
           fi
-          echo "commits<<EOF" >> $GITHUB_OUTPUT
-          echo "$COMMITS" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          {
+            echo "commits<<COMMITS_EOF"
+            echo "$COMMITS"
+            echo "COMMITS_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Generate release notes via Claude
         id: notes
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          RAW_COMMITS: ${{ steps.commits.outputs.commits }}
         run: |
-          RAW_COMMITS='${{ steps.commits.outputs.commits }}'
-
-          RESPONSE=$(curl -s https://api.anthropic.com/v1/messages \
-            -H "x-api-key: $ANTHROPIC_API_KEY" \
-            -H "anthropic-version: 2023-06-01" \
-            -H "content-type: application/json" \
-            -d "$(python3 -c "
-          import json
-          payload = {
-            'model': 'claude-sonnet-4-20250514',
-            'max_tokens': 1024,
-            'messages': [{
-              'role': 'user',
-              'content': 'You are writing release notes for the AEGIS™ Constitution governance documentation site. Convert these raw git commit messages into clear, professional release note entries. Keep them concise and human-readable. Return ONLY a markdown bulleted list, nothing else. No preamble, no explanation, no code fences.\n\nRaw commits:\n' + open('/dev/stdin').read()
-            }]
-          }
-          print(json.dumps(payload))
-          " <<< "$RAW_COMMITS")")
-
-          NOTES=$(echo "$RESPONSE" | python3 -c "
-          import sys, json
-          data = json.load(sys.stdin)
-          print(data['content'][0]['text'])
-          ")
-
-          echo "notes<<EOF" >> $GITHUB_OUTPUT
-          echo "$NOTES" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          NOTES=$(python3 scripts/generate-release-notes.py)
+          {
+            echo "notes<<NOTES_EOF"
+            echo "$NOTES"
+            echo "NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Update release notes file
         id: update_file
+        env:
+          TAG: ${{ steps.calver.outputs.tag }}
+          HASH: ${{ steps.commit.outputs.hash }}
+          YEAR: ${{ steps.calver.outputs.year }}
+          MONTH: ${{ steps.calver.outputs.month }}
+          DAY: ${{ steps.calver.outputs.day }}
+          NOTES: ${{ steps.notes.outputs.notes }}
         run: |
-          YEAR="${{ steps.calver.outputs.year }}"
-          MONTH="${{ steps.calver.outputs.month }}"
-          DAY="${{ steps.calver.outputs.day }}"
-          TAG="${{ steps.calver.outputs.tag }}"
-          HASH="${{ steps.commit.outputs.hash }}"
-
-          FILE="src/content/docs/releases/${YEAR}/${MONTH}.md"
-          mkdir -p "src/content/docs/releases/${YEAR}"
-
-          MONTH_NAME=$(date +'%B')
-          YEAR_FULL=$(date +'%Y')
-
-          python3 - << PYEOF
-import re, os
-
-tag = "${TAG}"
-hash_val = "${HASH}"
-day = "${DAY}"
-file_path = "${FILE}"
-month_name = "${MONTH_NAME}"
-year_full = "${YEAR_FULL}"
-
-notes = """${{ steps.notes.outputs.notes }}"""
-
-new_build_block = f"*Build: {hash_val}*\n{notes}\n"
-new_day_section = f"## {tag}\n\n{new_build_block}\n"
-
-if not os.path.exists(file_path):
-    content = f"""---
-title: "{month_name} {year_full}"
-description: "Release notes for {month_name} {year_full}"
-template: doc
-sidebar:
-  hidden: true
----
-
-{new_day_section}"""
-    with open(file_path, 'w') as f:
-        f.write(content)
-else:
-    with open(file_path, 'r') as f:
-        content = f.read()
-
-    heading = f"## {tag}"
-
-    if heading in content:
-        # Same day, different build — insert new build block after heading
-        pattern = f'({re.escape(heading)}\n\n)'
-        replacement = f'\\1{new_build_block}\n'
-        content = re.sub(pattern, replacement, content, count=1)
-    else:
-        # New day — prepend before first ## heading after frontmatter
-        match = re.search(r'\n(## )', content)
-        if match:
-            pos = match.start() + 1
-            content = content[:pos] + new_day_section + content[pos:]
-        else:
-            content += f"\n{new_day_section}"
-
-    with open(file_path, 'w') as f:
-        f.write(content)
-
-print(f"Updated {file_path}")
-PYEOF
-
-          echo "file=$FILE" >> $GITHUB_OUTPUT
+          python3 scripts/update-release-notes.py
+          echo "file=src/content/docs/releases/${YEAR}/${MONTH}.md" >> "$GITHUB_OUTPUT"
 
       - name: Create and push tag
         run: |
@@ -175,17 +99,20 @@ PYEOF
         run: |
           TAG="${{ steps.calver.outputs.tag }}"
           FILE="${{ steps.update_file.outputs.file }}"
-          BRANCH="release/${TAG}-${{ steps.commit.outputs.hash }}"
+          YEAR="${{ steps.calver.outputs.year }}"
+          MONTH="${{ steps.calver.outputs.month }}"
+          HASH="${{ steps.commit.outputs.hash }}"
+          BRANCH="release/${TAG}-${HASH}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git add "$FILE"
-          git commit -m "docs: release notes for ${TAG} (build ${{ steps.commit.outputs.hash }})"
+          git commit -m "docs: release notes for ${TAG} (build ${HASH})"
           git push origin "$BRANCH"
 
           gh pr create \
-            --title "Release notes: ${TAG} (build ${{ steps.commit.outputs.hash }})" \
+            --title "Release notes: ${TAG} (build ${HASH})" \
             --body "Auto-generated release notes for ${TAG}. Review and merge to publish to \`/releases/${YEAR}/${MONTH}\`." \
             --base main \
             --head "$BRANCH"

--- a/scripts/generate-release-notes.py
+++ b/scripts/generate-release-notes.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+Generate release notes from git commit messages using the Claude API.
+
+Reads:
+  ANTHROPIC_API_KEY — from environment
+  RAW_COMMITS      — from environment (newline-separated commit messages)
+
+Outputs the generated notes to stdout.
+"""
+
+import json
+import os
+import sys
+import urllib.request
+
+api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+raw_commits = os.environ.get("RAW_COMMITS", "")
+
+if not api_key:
+    print("Warning: ANTHROPIC_API_KEY not set, using raw commits", file=sys.stderr)
+    print(raw_commits)
+    sys.exit(0)
+
+if not raw_commits.strip():
+    print("- No commits since last release")
+    sys.exit(0)
+
+payload = {
+    "model": "claude-sonnet-4-20250514",
+    "max_tokens": 1024,
+    "messages": [
+        {
+            "role": "user",
+            "content": (
+                "You are writing release notes for the AEGIS™ Constitution "
+                "governance documentation site. Convert these raw git commit "
+                "messages into clear, professional release note entries. Keep "
+                "them concise and human-readable. Return ONLY a markdown "
+                "bulleted list, nothing else. No preamble, no explanation, "
+                "no code fences.\n\nRaw commits:\n" + raw_commits
+            ),
+        }
+    ],
+}
+
+req = urllib.request.Request(
+    "https://api.anthropic.com/v1/messages",
+    data=json.dumps(payload).encode("utf-8"),
+    headers={
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+    },
+)
+
+try:
+    with urllib.request.urlopen(req) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+        print(data["content"][0]["text"])
+except Exception as e:
+    print(f"Warning: Claude API call failed ({e}), using raw commits", file=sys.stderr)
+    print(raw_commits)

--- a/scripts/update-release-notes.py
+++ b/scripts/update-release-notes.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""
+Update release notes file for a CalVer release.
+
+Reads configuration from environment variables:
+  TAG         — CalVer tag (e.g., v26.3.22)
+  HASH        — Short commit hash
+  DAY         — Day of month
+  YEAR        — Two-digit year
+  MONTH       — Month number
+  NOTES       — Markdown release notes (bulleted list)
+"""
+
+import re
+import os
+from datetime import datetime
+
+tag = os.environ["TAG"]
+hash_val = os.environ["HASH"]
+day = os.environ["DAY"]
+year = os.environ["YEAR"]
+month = os.environ["MONTH"]
+notes = os.environ.get("NOTES", "- No release notes generated")
+
+month_name = datetime.now().strftime("%B")
+year_full = datetime.now().strftime("%Y")
+
+file_path = f"src/content/docs/releases/{year}/{month}.md"
+os.makedirs(os.path.dirname(file_path), exist_ok=True)
+
+new_build_block = f"*Build: {hash_val}*\n{notes}\n"
+new_day_section = f"## {tag}\n\n{new_build_block}\n"
+
+if not os.path.exists(file_path):
+    content = f"""---
+title: "{month_name} {year_full}"
+description: "Release notes for {month_name} {year_full}"
+template: doc
+sidebar:
+  hidden: true
+---
+
+{new_day_section}"""
+    with open(file_path, "w") as f:
+        f.write(content)
+else:
+    with open(file_path, "r") as f:
+        content = f.read()
+
+    heading = f"## {tag}"
+
+    if heading in content:
+        # Same day, different build — insert new build block after heading
+        pattern = f"({re.escape(heading)}\n\n)"
+        replacement = f"\\1{new_build_block}\n"
+        content = re.sub(pattern, replacement, content, count=1)
+    else:
+        # New day — prepend before first ## heading after frontmatter
+        match = re.search(r"\n(## )", content)
+        if match:
+            pos = match.start() + 1
+            content = content[:pos] + new_day_section + content[pos:]
+        else:
+            content += f"\n{new_day_section}"
+
+    with open(file_path, "w") as f:
+        f.write(content)
+
+print(f"Updated {file_path}")


### PR DESCRIPTION
## Summary

- Fixed invalid YAML syntax on line 110 (heredoc + `${{ }}` expression conflict)
- Extracted Python logic into standalone scripts:
  - `scripts/generate-release-notes.py` — Claude API call with graceful fallback
  - `scripts/update-release-notes.py` — release notes file creation/update
- Environment variables instead of shell interpolation in heredocs
- Proper `GITHUB_OUTPUT` multiline syntax

## Test plan

- [ ] Workflow YAML passes lint validation
- [ ] Merge to main triggers the workflow without YAML parse errors
- [ ] Tag is created with CalVer format
- [ ] Release notes PR is generated (requires `ANTHROPIC_API_KEY` secret)

🤖 Generated with [Claude Code](https://claude.com/claude-code)