### PR TITLE
chore: pin Cloudflare Pages cache policy in the repo

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,86 @@
+# Cloudflare Pages response headers
+# ──────────────────────────────────
+# Per-path Cache-Control policy for aegis-constitution.com.
+#
+# Why this file exists:
+#
+#   1. Repo-as-truth. Cache policy is a behavior of the site. Site
+#      behaviors belong in the repo, not in a dashboard nobody reads.
+#      Every change is versioned, reviewable, and auditable.
+#
+#   2. Drift protection. At some point prior to 2026-04-12 a zone-level
+#      setting emitted `s-maxage=604800` (7 days) on HTML responses,
+#      with no audit trail. Deleted pages were sitting at the edge for
+#      a week after they were removed from origin. This file pins the
+#      correct policy so the same regression can't happen silently.
+#
+#   3. Granularity. Zone-level settings are global. This file sets
+#      long TTLs for fingerprinted / immutable assets (fonts,
+#      /_astro/* bundles) while keeping HTML on a short leash so
+#      edits and deletions propagate quickly.
+#
+#   4. Portability. If the site ever moves off Cloudflare Pages, this
+#      file travels with it — Netlify, Vercel, and most static hosts
+#      read the same format.
+#
+# Matching rules:
+#
+#   - Cloudflare Pages applies ALL matching rules per request and
+#     merges the header sets. For conflicting headers, the more
+#     specific rule wins. So specific patterns can safely live above
+#     the catch-all `/*`.
+
+# ─────────────────────────────────────────────────────────────
+# Long-lived immutable assets — cache for a year
+# ─────────────────────────────────────────────────────────────
+
+# Astro's fingerprinted JS/CSS bundles. Filenames include a content
+# hash, so the file at a given URL never changes. Safe to cache
+# aggressively and tell the browser not to revalidate.
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Self-hosted font files. Content is stable; filenames don't change
+# between deploys.
+/fonts/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# ─────────────────────────────────────────────────────────────
+# Moderate TTLs — stable but not strictly immutable
+# ─────────────────────────────────────────────────────────────
+
+# Brand and icon assets — change rarely, cache for a day.
+/favicon.svg
+  Cache-Control: public, max-age=86400
+
+/OG_image.png
+  Cache-Control: public, max-age=86400
+
+/OG_image.svg
+  Cache-Control: public, max-age=86400
+
+# PDFs — regenerated occasionally by the print workflow.
+/*.pdf
+  Cache-Control: public, max-age=86400
+
+# ─────────────────────────────────────────────────────────────
+# Frequently-updated assets — short TTL
+# ─────────────────────────────────────────────────────────────
+
+# Pagefind search index — rebuilt on every deploy. Short TTL so
+# search index updates (new pages, removed pages) propagate fast.
+/pagefind/*
+  Cache-Control: public, max-age=300
+
+# ─────────────────────────────────────────────────────────────
+# HTML — always revalidate
+# ─────────────────────────────────────────────────────────────
+
+# Catch-all. Applied to every path that doesn't match a more specific
+# rule above — primarily the release notes tree, the legal pages,
+# and the rendered MDX documents. `max-age=0, must-revalidate` means
+# the browser can store the response but must check with the origin
+# before serving it. This keeps edits and deletions visible within
+# seconds rather than days.
+/*
+  Cache-Control: public, max-age=0, must-revalidate


### PR DESCRIPTION
## Summary

Adds a \`public/_headers\` file that pins cache policy per path as code, instead of relying on a Cloudflare zone-level setting with no audit trail.

## Background

While investigating why \`/releases/26/4/9/\` was still serving a deleted page after PR #81 merged, I found this response header:

\`\`\`
Cache-Control: public, s-maxage=604800
Age: 1735
\`\`\`

That's a **7-day edge cache** baked into the stored response. At some earlier point, a zone-level Cloudflare setting emitted this TTL on HTML responses, pinning deleted pages at the edge for a week after they were removed from origin. There's no commit, no PR, no changelog explaining when the setting changed — it just drifted.

Currently, CF is correctly emitting \`max-age=0, must-revalidate\` on fresh responses (I verified on \`/\`, \`/releases/26/4/11/\`, and the direct \`pages.dev\` URL). So the config is safe right now. But we have no protection against silent regressions, and no way to audit changes.

## Fix

Ship a \`public/_headers\` file that is the canonical cache policy for the site. Cloudflare Pages reads this at deploy time and applies per-path rules to every response.

### Policy

| Path | TTL | Rationale |
|---|---|---|
| \`/_astro/*\` | 1 year, immutable | Astro fingerprints JS/CSS with content hashes |
| \`/fonts/*\` | 1 year, immutable | Self-hosted fonts, filenames stable |
| \`/favicon.svg\` | 1 day | Brand asset, changes rarely |
| \`/OG_image.*\` | 1 day | Social cards, changes rarely |
| \`/*.pdf\` | 1 day | Print artifacts |
| \`/pagefind/*\` | 5 minutes | Search index, regenerated per deploy |
| \`/*\` (catch-all) | 0, must-revalidate | HTML — edits and deletions propagate fast |

## What this is NOT

This PR does **not** fix the currently-stale edge cache for \`/releases/26/4/9/\`. That stored response is already at the edge with the old headers baked in and will sit there until either (a) the 7-day TTL expires naturally, or (b) someone manually purges it via the Cloudflare dashboard. This file only governs *future* responses.

Recommended manual action after merge: **Cloudflare dashboard → aegis-constitution.com zone → Caching → Purge Cache → Purge Everything**. Safe for a docs site; just one extra origin fetch per page on next visit.

## Test plan

- [x] Local build copies \`public/_headers\` to \`dist/_headers\`
- [x] File syntax follows CF Pages format (verified against docs)
- [ ] Post-merge: fresh response from \`/releases/26/4/11/\` shows new headers from this file
- [ ] Post-merge: fresh response from \`/_astro/*\` shows \`max-age=31536000, immutable\`
- [ ] Post-purge: \`/releases/26/4/9/\` returns 404 (was 200 via stale cache)

## Benefits beyond the immediate fix

- Fingerprinted JS/CSS bundles can now be cached for a year — previously every browser was re-validating them on every page load because the zone-wide policy was \`max-age=0\`
- Fonts get the same treatment — meaningful perf win on first-paint
- Any future cache policy change goes through PR review
- The file is portable if we ever move off CF Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)