### PR TITLE
refactor: migrate Sidebar to shared design-system component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "aegis-constitution",
       "version": "0.0.1",
       "dependencies": {
-        "@aegis-initiative/design-system": "^0.5.1",
+        "@aegis-initiative/design-system": "^0.6.0",
         "@astrojs/mdx": "^5.0.2",
         "@pagefind/default-ui": "^1.4.0",
         "astro": "^6.0.8"
@@ -24,9 +24,9 @@
       }
     },
     "node_modules/@aegis-initiative/design-system": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@aegis-initiative/design-system/-/design-system-0.5.1.tgz",
-      "integrity": "sha512-DPfrOn3ZgXeitKzruNQ8CIwrui27Vk6lSm3S15BmoRipMzOBBjwtVbtcRs82LOBCK1l62ZPylvv75fbpdwtSWg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@aegis-initiative/design-system/-/design-system-0.6.0.tgz",
+      "integrity": "sha512-opB8HCVBmq0LwMMjWF4ACQQ9BS1CprJODbOziEkwExnzDAp2XFWiYX5+4Qhq/sA/9b3Ke97vDGhCtkFL+86SvQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.12.0"
@@ -1829,17 +1829,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
-      }
-    },
-    "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/unist": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@aegis-initiative/design-system": "^0.5.1",
+    "@aegis-initiative/design-system": "^0.6.0",
     "@astrojs/mdx": "^5.0.2",
     "@pagefind/default-ui": "^1.4.0",
     "astro": "^6.0.8"

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -1,7 +1,22 @@
 ---
+/**
+ * Site-specific Sidebar wrapper.
+ * Declares the aegis-constitution nav structure and delegates rendering
+ * to the shared design-system Sidebar component.
+ */
+import SharedSidebar from '@aegis-initiative/design-system/components/Sidebar.astro';
+
+interface NavItem {
+  label: string;
+  slug: string;
+  items?: NavItem[];
+}
+
+// Version badge — derived from the VERSION file via readSiteVersion()
+// in astro.config.mjs, which populates AEGIS_VERSION.
 const version = import.meta.env.AEGIS_VERSION ?? 'dev';
 const isCalVer = /^v\d{2}\.\d+\.\d+/.test(version);
-let versionHref = '#';
+let versionHref: string | undefined;
 if (isCalVer) {
   const match = version.match(/^v(\d+)\.(\d+)\.(\d+)/);
   if (match) {
@@ -10,9 +25,7 @@ if (isCalVer) {
   }
 }
 
-const pathname = Astro.url.pathname;
-
-const nav = [
+const nav: NavItem[] = [
   {
     label: 'Constitution',
     slug: 'constitution',
@@ -76,232 +89,6 @@ const nav = [
     ],
   },
 ];
-
-function isActive(slug: string): boolean {
-  return pathname === `/${slug}/` || pathname === `/${slug}`;
-}
-
-function isGroupActive(items: { slug: string }[]): boolean {
-  return items.some(item => isActive(item.slug));
-}
 ---
 
-<nav class="sidebar" id="sidebar" aria-label="Documentation navigation">
-  <div class="sidebar-inner">
-
-    {nav.map((group) => (
-      <details class="nav-group" open={isGroupActive(group.items)}>
-        <summary class="nav-group-label">
-          <span>{group.label}</span>
-          <svg class="caret" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M6 9l6 6 6-6"/>
-          </svg>
-        </summary>
-        <ul class="nav-items">
-          {group.items.map((item) => (
-            <li>
-              <a href={`/${item.slug}/`} class={`nav-link ${isActive(item.slug) ? 'active' : ''}`} aria-current={isActive(item.slug) ? 'page' : undefined}>{item.label}</a>
-            </li>
-          ))}
-        </ul>
-      </details>
-    ))}
-  </div>
-
-  <!-- Version badge — mobile only, shown in sidebar footer -->
-  <div class="sidebar-version">
-    {isCalVer ? (
-      <a href={versionHref} class="sidebar-version-badge" aria-label={`Version ${version} — view release notes`}>{version}</a>
-    ) : (
-      <span class="sidebar-version-badge">{version}</span>
-    )}
-  </div>
-</nav>
-
-<!-- Mobile overlay -->
-<div class="sidebar-overlay" id="sidebar-overlay"></div>
-
-<style>
-  .sidebar {
-    width: 320px;
-    flex-shrink: 0;
-    background-color: var(--sidebar-bg);
-    border-right: 1px solid var(--color-border-subtle);
-    overflow-y: auto;
-    position: fixed;
-    top: calc(4rem + var(--aegis-nav-height, 0px));
-    left: 0;
-    height: calc(100vh - 4rem - var(--aegis-nav-height, 0px));
-    display: flex;
-    flex-direction: column;
-    z-index: 40;
-
-    /* Mobile: hidden by default */
-    display: none;
-  }
-
-  .sidebar-inner {
-    padding: 1rem 0;
-    flex: 1;
-  }
-
-  .nav-group {
-    /* no border — cleaner visual separation via spacing */
-  }
-
-  .nav-group-label {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0.75rem 1.25rem;
-    cursor: pointer;
-    font-family: "IBM Plex Sans", system-ui, sans-serif;
-    font-weight: 600;
-    font-size: 0.875rem;
-    color: var(--color-text);
-    list-style: none;
-    user-select: none;
-  }
-
-  .nav-group-label::-webkit-details-marker {
-    display: none;
-  }
-
-  .nav-group-label:hover {
-    color: var(--color-accent);
-  }
-
-  .caret {
-    transition: transform 0.2s ease;
-    flex-shrink: 0;
-  }
-
-  details[open] .caret {
-    transform: rotate(180deg);
-  }
-
-  .nav-items {
-    list-style: none;
-    padding: 0.25rem 0 0.75rem;
-    margin-left: 1.25rem;
-    border-left: 1px solid var(--color-border);
-  }
-
-  .nav-link {
-    display: block;
-    padding: 0.3rem 1rem 0.3rem 1rem;
-    margin-left: -1px;
-    font-size: 0.875rem;
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    line-height: 1.4;
-    border-left: 2px solid transparent;
-    transition: color 0.15s, border-color 0.15s, background-color 0.15s;
-  }
-
-  .nav-link:hover {
-    color: var(--color-accent);
-    border-left-color: var(--color-text-muted);
-  }
-
-  .nav-link.active {
-    color: #ffffff;
-    background-color: var(--color-accent);
-    border-left-color: var(--color-accent);
-    font-weight: 600;
-    border-radius: 0 4px 4px 0;
-  }
-
-  :global([data-theme="dark"]) .nav-link.active {
-    color: #161616;
-  }
-
-  /* Version badge in sidebar footer — mobile only */
-  .sidebar-version {
-    display: block;
-    padding: 0.75rem 1.25rem;
-    border-top: 1px solid var(--color-border-subtle);
-  }
-
-  .sidebar-version-badge {
-    font-size: 0.75rem;
-    color: var(--color-text-muted);
-    text-decoration: none;
-    font-family: monospace;
-    letter-spacing: 0.02em;
-  }
-
-  .sidebar-version-badge:hover {
-    color: var(--color-accent);
-    text-decoration: underline;
-  }
-
-  .sidebar-overlay {
-    display: none;
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.4);
-    z-index: 50;
-  }
-
-  /* Wide screens: show sidebar, hide sidebar version badge */
-  @media (min-width: 1024px) {
-    .sidebar {
-      display: flex;
-    }
-    .sidebar-version {
-      display: none;
-    }
-  }
-
-  /* Mobile: sidebar as drawer */
-  .sidebar.open {
-    display: flex;
-    position: fixed;
-    top: calc(4rem + var(--aegis-nav-height, 0px));
-    left: 0;
-    height: calc(100vh - 4rem - var(--aegis-nav-height, 0px));
-    z-index: 60;
-    width: min(320px, 85vw);
-  }
-
-  .sidebar-overlay.open {
-    display: block;
-  }
-</style>
-
-<script>
-  // Accordion — only one group open at a time
-  const details = document.querySelectorAll<HTMLDetailsElement>('.nav-group');
-  details.forEach((detail) => {
-    detail.addEventListener('toggle', () => {
-      if (detail.open) {
-        details.forEach((other) => {
-          if (other !== detail && other.open) other.open = false;
-        });
-      }
-    });
-  });
-
-  // Mobile drawer toggle
-  const sidebar = document.getElementById('sidebar');
-  const overlay = document.getElementById('sidebar-overlay');
-
-  function openSidebar() {
-    sidebar?.classList.add('open');
-    overlay?.classList.add('open');
-    document.body.style.overflow = 'hidden';
-  }
-
-  function closeSidebar() {
-    sidebar?.classList.remove('open');
-    overlay?.classList.remove('open');
-    document.body.style.overflow = '';
-  }
-
-  overlay?.addEventListener('click', closeSidebar);
-
-  // Expose for header menu button
-  (window as any).openSidebar = openSidebar;
-  (window as any).closeSidebar = closeSidebar;
-</script>
+<SharedSidebar nav={nav} version={version} versionHref={versionHref} />


### PR DESCRIPTION
## Summary

Phase 4 of [aegis-initiative/aegis-initiative#7](https://github.com/aegis-initiative/aegis-initiative/issues/7).

Replaces the local Sidebar.astro (306 lines of rendering + nav data + version badge + mobile drawer logic) with a thin wrapper (~95 lines) that declares only the constitution-specific nav data and delegates everything else to \`@aegis-initiative/design-system/components/Sidebar.astro\`.

## What moves to the package

- Rendering (nav accordion, flat legal nav mode)
- Active-state detection
- Accordion one-open-at-a-time behavior
- Mobile drawer open/close
- Version badge (shown in mobile footer, hidden on desktop)
- All styles (320px desktop, 85vw drawer mobile)
- All breakpoint logic

## What stays in this repo

- Constitution-specific nav data (Constitution, Doctrine, Principles, Protocols)
- Version string derivation from \`import.meta.env.AEGIS_VERSION\` (populated by \`readSiteVersion()\` in astro.config.mjs)
- Mapping \`vYY.M.D\` to a release-notes URL

## Net effect

**-283 lines** of Sidebar code replaced with a thin wrapper. Any future improvement to sidebar rendering, accordion, mobile drawer behavior, or version badge propagates to constitution automatically on the next dependency bump.

## Test plan

- [ ] Cloudflare preview build passes
- [ ] Visit /constitution/ — article accordion opens with active item highlighted
- [ ] Visit /doctrine/article-i/ — nav shows correct open group + active item
- [ ] Visit /principles/ — nav works
- [ ] Resize to mobile — menu button in header toggles drawer
- [ ] Version badge visible in mobile drawer footer, hidden on desktop
- [ ] Version badge links to /releases/YY/M/D/ for calver versions

## Depends on

[@aegis-initiative/design-system@0.6.0](https://www.npmjs.com/package/@aegis-initiative/design-system/v/0.6.0) — already published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)