### PR TITLE
feat(404): add report beacon and explicit report link

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -42,7 +42,11 @@ import AegisLogo from '@aegis-initiative/design-system/components/AegisLogo.astr
         <p class="suggestions-label">Did you mean:</p>
         <ul class="suggestions-list" id="suggestions-list"></ul>
       </div>
-      <a href="/" class="error-link">Return to Home</a>
+      <div class="error-actions">
+        <a href="/" class="error-link">Return to Home</a>
+        <a href="#" id="report-link" class="error-report">Report this broken link</a>
+      </div>
+      <p class="error-path" id="error-path"></p>
     </main>
 
     <div class="error-footer">
@@ -110,7 +114,29 @@ import AegisLogo from '@aegis-initiative/design-system/components/AegisLogo.astr
           return d[m][n];
         }
 
-        var current = window.location.pathname.toLowerCase().replace(/\/+$/, '').replace(/\/+/g, '/');
+        var requested = window.location.pathname;
+        var pathEl = document.getElementById('error-path');
+        if (pathEl) pathEl.textContent = 'Requested: ' + requested;
+
+        try {
+          var body = JSON.stringify({
+            domain: window.location.host,
+            path: requested,
+            referrer: document.referrer || null,
+            userAgent: navigator.userAgent,
+            timestamp: new Date().toISOString(),
+          });
+          if (navigator.sendBeacon) {
+            navigator.sendBeacon('https://notify.aegis-initiative.com/404', body);
+          }
+        } catch (_e) { /* best-effort */ }
+
+        var reportLink = document.getElementById('report-link');
+        if (reportLink) {
+          reportLink.href = 'mailto:ken@aegis-initiative.com?subject=Broken%20link%20on%20' + encodeURIComponent(window.location.host) + '&body=' + encodeURIComponent('Requested: ' + requested + '\nReferrer: ' + (document.referrer || '(none)'));
+        }
+
+        var current = requested.toLowerCase().replace(/\/+$/, '').replace(/\/+/g, '/');
         if (!current) return;
 
         var scored = routes.map(function (r) {
@@ -296,9 +322,17 @@ import AegisLogo from '@aegis-initiative/design-system/components/AegisLogo.astr
     color: var(--color-accent-high);
   }
 
+  .error-actions {
+    display: flex;
+    gap: 1rem;
+    margin-top: 1rem;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
   .error-link {
     display: inline-block;
-    margin-top: 1rem;
     padding: 0.625rem 1.5rem;
     border-radius: 999px;
     background-color: var(--color-accent);
@@ -313,6 +347,21 @@ import AegisLogo from '@aegis-initiative/design-system/components/AegisLogo.astr
   .error-link:hover {
     background-color: var(--color-accent-high);
     color: #ffffff;
+  }
+
+  .error-report {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    text-decoration: underline;
+  }
+
+  .error-path {
+    margin-top: 0.75rem;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+    font-family: monospace;
+    word-break: break-all;
+    max-width: 640px;
   }
 
   .error-footer {


### PR DESCRIPTION
## Summary

- Extend the existing 404 page with a \`navigator.sendBeacon\` call to a central broken-link reporting endpoint.
- Show the requested path for transparency.
- Add a \`mailto:\` "Report this broken link" fallback for cases where the beacon is blocked.

## Context

Part of an ecosystem-wide 404 deployment. aegis-constitution already had a strong custom 404 page — this PR only layers on the reporting infrastructure so broken-link telemetry is consistent across all 5 public AEGIS sites.

Sister PRs:
- [aegis-governance#141](https://github.com/aegis-initiative/aegis-governance/pull/141) — new 404 + ~270 broken-link fixes
- [aegis-docs#34](https://github.com/aegis-initiative/aegis-docs/pull/34) — new 404
- [aegis-federation#19](https://github.com/aegis-initiative/aegis-federation/pull/19) — new 404
- [aegis-initiative#38](https://github.com/aegis-initiative/aegis-initiative/pull/38) — new 404
- aegis-ops PR — \`notify.aegis-initiative.com/404\` Worker scaffold

The beacon endpoint (\`notify.aegis-initiative.com/404\`) is referenced but not yet deployed. \`navigator.sendBeacon\` fails silently so there's zero visible effect until the Worker goes live.

## Test plan

- [ ] \`npm run build\` succeeds (PDF generation still works)
- [ ] Visit \`/does-not-exist\` → 404 renders with fuzzy suggestions, requested path visible, report link present
- [ ] Existing route behavior unchanged
- [ ] DevTools Network tab shows the beacon \`POST\` attempt (will fail until the Worker is deployed — expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)