### PR TITLE
docs: release notes for 2026-04-29

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,5 +1,5 @@
 {
-  "tag": "v26.4.20",
-  "commit": "c0bb33b",
-  "released_at": "2026-04-21T06:56:31Z"
+  "tag": "v26.4.29",
+  "commit": "df09969",
+  "released_at": "2026-04-30T07:25:14Z"
 }

--- a/src/content/docs/releases/26/4.md
+++ b/src/content/docs/releases/26/4.md
@@ -6,6 +6,14 @@ sidebar:
   hidden: true
 ---
 
+## Release / v26.4.29
+
+*Builds: df09969* — [Development Log →](/releases/26/4/29/)
+
+- Added a sitemap and structured data to each page to improve search engine visibility and discoverability of the Constitution documentation.
+
+---
+
 ## Release / v26.4.20
 
 *Builds: c0bb33b* — [Development Log →](/releases/26/4/20/)

--- a/src/content/docs/releases/26/4/29.md
+++ b/src/content/docs/releases/26/4/29.md
@@ -6,6 +6,13 @@ sidebar:
   hidden: true
 ---
 
+## Release / v26.4.29
+
+*Builds: df09969*
+
+- Added a sitemap and structured data to each page to improve search engine visibility and discoverability of the Constitution documentation.
+
+---
 ## Development Log
 
 - feat(seo): generate sitemap and add per-page structured data (#94) (df09969)

--- a/src/content/docs/releases/26/4/29.md
+++ b/src/content/docs/releases/26/4/29.md
@@ -1,0 +1,11 @@
+---
+title: "April 29, 2026"
+description: "Development log for April 29, 2026"
+template: doc
+sidebar:
+  hidden: true
+---
+
+## Development Log
+
+- feat(seo): generate sitemap and add per-page structured data (#94) (df09969)

--- a/src/content/docs/releases/index.md
+++ b/src/content/docs/releases/index.md
@@ -12,6 +12,7 @@ For the broader project timeline — pre-release milestones, publication history
 
 ### [April](/releases/26/4/)
 
+- [v26.4.29](/releases/26/4/#release--v26429) — Added sitemap and structured data for improved SEO
 - [v26.4.20](/releases/26/4/#release--v26420) — Added broken link reporting from 404 pages
 - [v26.4.13](/releases/26/4/#release--v26413) — Updated design system components and documentation links
 - [v26.4.12](/releases/26/4/#release--v26412) — Version badge fix, Node 22 upgrade, and nightly release improvements


### PR DESCRIPTION
Daily release rollup — dev log, monthly summary, and index update for 2026-04-29.