### PR TITLE
feat(seo): add ecosystem sameAs and enable Labs in cross-site nav

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
+import sitemap from '@astrojs/sitemap';
 import { readSiteVersion } from '@aegis-initiative/design-system/build';
 
 // Version is read from the committed VERSION file at the repo root.
@@ -12,5 +13,5 @@ process.env.AEGIS_VERSION = readSiteVersion();
 // https://astro.build/config
 export default defineConfig({
   site: 'https://aegis-constitution.com',
-  integrations: [mdx()],
+  integrations: [mdx(), sitemap()],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "astro": "^6.0.8"
       },
       "devDependencies": {
+        "@astrojs/sitemap": "^3.7.2",
         "mime-types": "^3.0.2",
         "pagefind": "^1.4.0",
         "puppeteer": "^24.40.0"
@@ -125,6 +126,18 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.2.tgz",
+      "integrity": "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -1835,11 +1848,21 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/unist": {
@@ -1947,6 +1970,13 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -5881,6 +5911,43 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
+    "node_modules/sitemap/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/sitemap/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -5961,6 +6028,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/streamx": {
       "version": "2.25.0",
@@ -6223,8 +6297,8 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "astro": "^6.0.8"
   },
   "devDependencies": {
+    "@astrojs/sitemap": "^3.7.2",
     "mime-types": "^3.0.2",
     "pagefind": "^1.4.0",
     "puppeteer": "^24.40.0"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -40,4 +40,4 @@ Disallow: /
 Allow: /.well-known/aegis/
 
 # Sitemap
-Sitemap: https://aegis-constitution.com/sitemap.xml
+Sitemap: https://aegis-constitution.com/sitemap-index.xml

--- a/src/layouts/DocLayout.astro
+++ b/src/layouts/DocLayout.astro
@@ -14,6 +14,10 @@ const {
   title,
   description = "The canonical AEGIS™ governance charter — versioned, citeable, and openly licensed",
 } = Astro.props;
+
+const pageUrl = new URL(Astro.url.pathname, Astro.site).toString();
+const fullTitle = `${title} | AEGIS Constitution`;
+const isHome = Astro.url.pathname === "/" || Astro.url.pathname === "";
 ---
 
 <!doctype html>
@@ -51,6 +55,48 @@ const {
 
     <link rel="preload" href="/fonts/ibmplexsans-variablefont_wdthwght-webfont.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="/fonts/poppins-light-webfont.woff2" as="font" type="font/woff2" crossorigin />
+
+    <!-- Structured Data -->
+    <script type="application/ld+json" set:html={JSON.stringify({
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebSite",
+          "name": "AEGIS Constitution",
+          "url": "https://aegis-constitution.com",
+          "publisher": {
+            "@type": "Organization",
+            "name": "AEGIS Initiative",
+            "url": "https://aegis-initiative.com"
+          }
+        },
+        isHome ? {
+          "@type": "WebPage",
+          "name": fullTitle,
+          "url": pageUrl,
+          "description": description,
+          "isPartOf": { "@id": "https://aegis-constitution.com" },
+          "publisher": {
+            "@type": "Organization",
+            "name": "AEGIS Initiative",
+            "url": "https://aegis-initiative.com"
+          }
+        } : {
+          "@type": "TechArticle",
+          "headline": title,
+          "name": fullTitle,
+          "url": pageUrl,
+          "description": description,
+          "isPartOf": { "@id": "https://aegis-constitution.com" },
+          "publisher": {
+            "@type": "Organization",
+            "name": "AEGIS Initiative",
+            "url": "https://aegis-initiative.com"
+          }
+        }
+      ]
+    })} />
+
     <script is:inline>
       // Prevent FOUC — apply theme before paint
       (function () {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -77,6 +77,25 @@ import AegisWordmark from '@aegis-initiative/design-system/components/AegisWordm
       ]
     }
     </script>
+
+    <!-- Organization + ecosystem sameAs (cross-site SEO signal) -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "AEGIS Initiative",
+      "url": "https://aegis-initiative.com",
+      "sameAs": [
+        "https://aegis-initiative.com",
+        "https://aegis-constitution.com",
+        "https://aegis-governance.com",
+        "https://aegis-docs.com",
+        "https://aegis-federation.com",
+        "https://aegis-labs.dev",
+        "https://github.com/aegis-initiative"
+      ]
+    }
+    </script>
   </head>
   <body>
     <Header />


### PR DESCRIPTION
## Summary

Coordinated cross-site SEO + nav update landing in parallel across all 6 AEGIS Astro sites:

1. Adds per-page sitemap and structured data (sitemap-index.xml, JSON-LD blocks).
2. Standardizes Organization \`sameAs\` covering all 6 AEGIS domains + GitHub org so search engines treat them as one entity cluster.
3. Flips \`aegis-labs.dev\` to \`visible: true\` in the shared cross-site nav bar.

## Commits

- \`feat(seo): generate sitemap and add per-page structured data\`
- \`feat(seo): add ecosystem sameAs and enable Labs in cross-site nav\`

## Test plan

- [ ] Cloudflare Pages preview deploys cleanly
- [ ] Live verification post-merge: \`/sitemap-index.xml\` resolves; Labs link appears in the cross-site nav bar; Organization JSON-LD validates in Google's Rich Results Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)