### PR TITLE
fix(headers): add site-wide security response headers

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -106,3 +106,30 @@
 # to list HTML-serving path prefixes explicitly (/constitution/*,
 # /doctrine/*, /releases/*, etc.) so they don't overlap with the
 # immutable-asset rules above.
+
+# ─────────────────────────────────────────────────────────────
+# Security response headers — applied site-wide
+# ─────────────────────────────────────────────────────────────
+#
+# A /* rule is SAFE here even though the catch-all was removed above
+# for Cache-Control. Cloudflare Pages concatenates the values of
+# matching rules per header NAME; every header below is a distinct
+# name from Cache-Control, so they never merge with the per-path
+# cache rules and the concatenation regression documented above
+# cannot recur. Do NOT add Cache-Control to this block.
+#
+# The CSP intentionally sets only framing / base-uri / object
+# restrictions — NOT default-src / script-src / style-src — so it
+# hardens against clickjacking, <base> injection, and plugin
+# embedding without constraining how the site loads its own
+# scripts, styles, fonts, or the shared nav script. A full content
+# CSP (script-src incl. https://aegis-initiative.com, plus SRI on —
+# or self-hosting of — the shared nav script) is a tracked follow-up
+# that needs a per-site build + live verification before it can ship
+# safely.
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Cross-Origin-Opener-Policy: same-origin
+  Content-Security-Policy: frame-ancestors 'none'; base-uri 'self'; object-src 'none'


### PR DESCRIPTION
## Summary

Adds site-wide security response headers to close the "no security response headers" finding from the 2026-05-30 ecosystem security review (Low across the sites; **Medium on aegis-docs** because every page executes a cross-origin nav script with no CSP).

Headers added via a `/*` rule in `public/_headers`:

- `X-Frame-Options: DENY` + CSP `frame-ancestors 'none'` — clickjacking
- `X-Content-Type-Options: nosniff` — MIME sniffing
- `Referrer-Policy: strict-origin-when-cross-origin` — referrer leakage
- `Cross-Origin-Opener-Policy: same-origin` — cross-origin window isolation
- CSP `base-uri 'self'; object-src 'none'` — `<base>` injection + plugin embedding

## Why a `/*` rule is safe here (the concatenation gotcha)

The cache `/*` catch-all was previously removed because Cloudflare Pages **concatenates values per header name**, which merged `Cache-Control`. This block sets **only** security headers — all distinct names from `Cache-Control` — so it never merges with the per-path cache rules. The block is commented to forbid adding `Cache-Control` to it.

## Deliberately scoped CSP

The CSP omits `default-src`/`script-src`/`style-src`, so it cannot break how the site loads its own scripts, styles, fonts, or the shared nav script. A **full content CSP** (`script-src` incl. `https://aegis-initiative.com`) plus **SRI on / self-hosting of the shared nav script** is a tracked follow-up — it needs a per-site build + live verification before shipping.

## Canary — validate before replicate

**This is the canary of a 4-site sweep** (constitution, docs, federation, initiative — identical block). Suggested order: merge this, deploy, then verify the headers are live (e.g. `curl -sI https://aegis-constitution.com | grep -iE "x-frame|content-security|referrer|x-content|opener"`), confirm the site renders normally, then merge the other three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
