### PR TITLE
docs(readme): attribute AEGIS trademarks to AEGIS Initiative

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,10 @@ On March 7, 2026, AEGIS™ was submitted as an **unsolicited position statement*
 
 Licensed under [CC-BY-SA-4.0](LICENSE).
 
-AEGIS™ and **"Capability without constraint is not intelligence™"** are trademarks of **Finnoybu IP LLC**.\
+AEGIS™ and **"Capability without constraint is not intelligence™"** are trademarks of **AEGIS Initiative**.\
 Use of AEGIS™ marks in derivative works must not imply endorsement without explicit written permission.
 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — Finnoybu IP LLC*
+*AEGIS Initiative*


### PR DESCRIPTION
Changes the README trademark notice owner from `Finnoybu IP LLC` to `AEGIS Initiative` (a registered DBA for the owner) per the public-attribution rule. Operator clause (AEGIS Operations LLC) unchanged.