### PR TITLE
chore: entity naming consolidation + release-script model bump (clean re-application)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Creative Commons Attribution-ShareAlike 4.0 International
 
-Copyright (c) 2026 Finnoybu IP LLC
+Copyright (c) 2026 AEGIS Initiative
 
 You are free to:
 

--- a/scripts/generate-release-notes.py
+++ b/scripts/generate-release-notes.py
@@ -27,7 +27,7 @@ if not raw_commits.strip():
     sys.exit(0)
 
 payload = {
-    "model": "claude-sonnet-4-20250514",
+    "model": "claude-sonnet-4-6",
     "max_tokens": 1024,
     "messages": [
         {

--- a/scripts/nightly-release.py
+++ b/scripts/nightly-release.py
@@ -218,7 +218,7 @@ def generate_release_summary(raw_entries):
     joined = "\n".join(raw_entries)
 
     payload = {
-        "model": "claude-sonnet-4-5",
+        "model": "claude-sonnet-4-6",
         "max_tokens": 1024,
         "messages": [
             {
@@ -291,7 +291,7 @@ def generate_index_summary(release_entries):
     joined = "\n".join(release_entries)
 
     payload = {
-        "model": "claude-sonnet-4-5",
+        "model": "claude-sonnet-4-6",
         "max_tokens": 100,
         "messages": [
             {

--- a/sites/constitution/public/.well-known/aegis/manifest.json
+++ b/sites/constitution/public/.well-known/aegis/manifest.json
@@ -12,7 +12,7 @@
   },
   "organization": {
     "name": "AEGIS Initiative",
-    "legal_entity": "Finnoybu IP LLC",
+    "legal_entity": "AEGIS Initiative",
     "parent": "Finnoybu Holdings LLC"
   },
   "resources": [

--- a/sites/constitution/public/.well-known/aegis/metadata.json
+++ b/sites/constitution/public/.well-known/aegis/metadata.json
@@ -28,7 +28,7 @@
   },
   "organization": {
     "name": "AEGIS Initiative",
-    "legal_entity": "Finnoybu IP LLC",
+    "legal_entity": "AEGIS Initiative",
     "parent": "Finnoybu Holdings LLC",
     "domain": "aegis-platform.net",
     "github": "https://github.com/aegis-initiative"

--- a/sites/constitution/src/content/docs/about/index.md
+++ b/sites/constitution/src/content/docs/about/index.md
@@ -67,4 +67,4 @@ For copyright, trademark, and licensing information, see [Copyright, Trademark &
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*
-*AEGIS Initiative — Finnoybu IP LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/constitution/src/content/docs/contact/index.md
+++ b/sites/constitution/src/content/docs/contact/index.md
@@ -48,4 +48,4 @@ This is a small initiative. Responses to discussions and issues are best-effort,
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*
-*AEGIS Initiative — Finnoybu IP LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/constitution/src/content/docs/references.md
+++ b/sites/constitution/src/content/docs/references.md
@@ -53,4 +53,4 @@ This page collects all normative references cited across the AEGIS Constitution 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*
-*AEGIS Initiative — Finnoybu IP LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/constitution/src/content/docs/showcase/index.mdx
+++ b/sites/constitution/src/content/docs/showcase/index.mdx
@@ -156,4 +156,4 @@ This is a **prohibition** aside. It uses red for the border and title, with a li
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*
-*AEGIS Initiative — Finnoybu IP LLC*
+*AEGIS Initiative — AEGIS Initiative*


### PR DESCRIPTION
Re-applies the two commits from `chore/migrate-claude-opus-4-8` (bf83d02, 48a1b27) without the line-ending churn: that branch rewrote ~117 untouched files from LF to CRLF, which would have polluted every future diff.

Real changes (9 files, 10 lines):
- **Entity naming**: `Finnoybu IP LLC` → `AEGIS Initiative` in LICENSE, `.well-known/aegis/` metadata, and doc footers
- **Release scripts**: Claude model bumped to `claude-sonnet-4-6`

Verified byte-identical to the chore branch content modulo CR. The chore branch will be deleted after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)