### PR TITLE
fix: month-boundary mislabels in releases index + May monthly title

### DIFF
--- a/scripts/nightly-release.py
+++ b/scripts/nightly-release.py
@@ -364,8 +364,11 @@ def update_monthly(year, month, tag, builds_str, release_entries, day):
     """Add release entry to monthly file."""
     file_path = os.path.join(RELEASES_ROOT, f"{year}", f"{month}.md")
 
-    month_name = datetime.now(timezone.utc).strftime("%B")
-    year_full = datetime.now(timezone.utc).strftime("%Y")
+    # Derive the display name from the TARGET month, not the run date —
+    # the nightly rollup for the last day of a month runs on the 1st of
+    # the next month, which used to mislabel the monthly page.
+    month_name = datetime(2000 + int(year), int(month), 1).strftime("%B")
+    year_full = f"20{year}"
 
     entries_text = "\n".join(release_entries)
     new_section = f"""## Release / {tag}
@@ -433,8 +436,10 @@ def update_index(year, month, tag, summary):
         content = entry_pattern.sub(entry_line, content)
         print(f"Updated index entry for {base_tag}")
     else:
-        year_full = datetime.now(timezone.utc).strftime("%Y")
-        month_name = datetime.now(timezone.utc).strftime("%B")
+        # Use the TARGET month, not the run date — the rollup for the
+        # last day of a month runs on the 1st of the next month.
+        year_full = f"20{year}"
+        month_name = datetime(2000 + int(year), int(month), 1).strftime("%B")
         month_header = f"### [{month_name}](/releases/{year}/{month}/)"
         year_header = f"## {year_full}"
 

--- a/sites/constitution/src/content/docs/releases/26/5.md
+++ b/sites/constitution/src/content/docs/releases/26/5.md
@@ -1,6 +1,6 @@
 ---
-title: "June 2026"
-description: "Release notes for June 2026"
+title: "May 2026"
+description: "Release notes for May 2026"
 template: doc
 sidebar:
   hidden: true

--- a/sites/constitution/src/content/docs/releases/index.md
+++ b/sites/constitution/src/content/docs/releases/index.md
@@ -21,18 +21,14 @@ For the broader project timeline — pre-release milestones, publication history
 - [v26.6.1](/releases/26/6/#release--v2661) — Reorganized project structure for multi-site support and expansion
 
 
-### [June](/releases/26/5/)
+### [May](/releases/26/5/)
 
 - [v26.5.31](/releases/26/5/#release--v26531) — Added security headers and self-hosted navigation script
 
 
-### [May](/releases/26/4/)
-
-- [v26.4.30](/releases/26/4/#release--v26430) — Added ecosystem cross-references and enabled Labs in navigation
-
-
 ### [April](/releases/26/4/)
 
+- [v26.4.30](/releases/26/4/#release--v26430) — Added ecosystem cross-references and enabled Labs in navigation
 - [v26.4.29](/releases/26/4/#release--v26429) — Added sitemap and structured data for improved SEO
 - [v26.4.20](/releases/26/4/#release--v26420) — Added broken link reporting from 404 pages
 - [v26.4.13](/releases/26/4/#release--v26413) — Updated design system components and documentation links


### PR DESCRIPTION
The /releases/ index shows a duplicate **June** section (one pointing at `/releases/26/5/`) and a **May** section pointing at `/releases/26/4/`, and the May monthly page is titled "June 2026". Root cause: `nightly-release.py` derives month names from the rollup **run date** instead of the target month, so a month's final rollup (running on the 1st of the next month) mislabels everything it creates. Same fix already shipped for federation (#40) and initiative (aegis-initiative#59).

- Index: mislabeled June→May renamed, mislabeled May merged into April
- `26/5.md` retitled to May 2026
- Script derives names from the `--month` argument

Local build verified: one section per month, correct title on /releases/26/5/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)