### PR TITLE
docs: release notes for 2026-07-09

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,5 +1,5 @@
 {
-  "tag": "v26.7.7",
-  "commit": "38625cb",
-  "released_at": "2026-07-08T05:59:55Z"
+  "tag": "v26.7.9",
+  "commit": "f7505ff",
+  "released_at": "2026-07-10T06:19:20Z"
 }

--- a/sites/constitution/src/content/docs/releases/26/7.md
+++ b/sites/constitution/src/content/docs/releases/26/7.md
@@ -6,6 +6,14 @@ sidebar:
   hidden: true
 ---
 
+## Release / v26.7.9
+
+*Builds: f7505ff* — [Development Log →](/releases/26/7/9/)
+
+- fix: correct month labels in the releases index and May monthly page (#115) (f7505ff)
+
+---
+
 ## Release / v26.7.7
 
 *Builds: 9cecc16 – 38625cb* — [Development Log →](/releases/26/7/7/)

--- a/sites/constitution/src/content/docs/releases/26/7/9.md
+++ b/sites/constitution/src/content/docs/releases/26/7/9.md
@@ -1,0 +1,11 @@
+---
+title: "July 9, 2026"
+description: "Development log for July 9, 2026"
+template: doc
+sidebar:
+  hidden: true
+---
+
+## Development Log
+
+- fix: correct month labels in the releases index and May monthly page (#115) (f7505ff)

--- a/sites/constitution/src/content/docs/releases/26/7/9.md
+++ b/sites/constitution/src/content/docs/releases/26/7/9.md
@@ -6,6 +6,13 @@ sidebar:
   hidden: true
 ---
 
+## Release / v26.7.9
+
+*Builds: f7505ff*
+
+- fix: correct month labels in the releases index and May monthly page (#115) (f7505ff)
+
+---
 ## Development Log
 
 - fix: correct month labels in the releases index and May monthly page (#115) (f7505ff)

--- a/sites/constitution/src/content/docs/releases/index.md
+++ b/sites/constitution/src/content/docs/releases/index.md
@@ -12,6 +12,7 @@ For the broader project timeline — pre-release milestones, publication history
 
 ### [July](/releases/26/7/)
 
+- [v26.7.9](/releases/26/7/#release--v2679) — Fix incorrect month labels in releases index and May monthly page
 - [v26.7.7](/releases/26/7/#release--v2677) — Restore ecosystem nav bar and consolidate IP entity naming
 
 


### PR DESCRIPTION
Daily release rollup — dev log, monthly summary, and index update for 2026-07-09.